### PR TITLE
Remove jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.kotlin_version = "1.4.10"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -43,6 +43,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     implementation 'com.google.android.material:material:1.2.1'
-    implementation 'io.michaelrocks:libphonenumber-android:8.12.24'
+    implementation 'io.michaelrocks:libphonenumber-android:8.12.31'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.0'
 }


### PR DESCRIPTION
jCenter is going to be shut down. So, I remove it on this PR. In order to do it, I upgraded libphonenumber-android because its previous version existed on the jCenter.