### PR TITLE
Support dark mode using material components

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/lib/src/main/res/layout/bottom_sheet_country_picker.xml
+++ b/lib/src/main/res/layout/bottom_sheet_country_picker.xml
@@ -14,19 +14,18 @@
         android:paddingHorizontal="18dp"
         android:paddingVertical="20dp">
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="Country Code"
-            android:textColor="#232425"
             android:textSize="16sp" />
 
-        <ImageButton
+        <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/imageButtonClose"
             android:layout_width="20dp"
             android:layout_height="20dp"
-            android:background="?actionBarItemBackground"
+            android:tint="?attr/colorOnSurface"
             android:src="@drawable/ic_close_24dp" />
 
     </LinearLayout>
@@ -36,7 +35,6 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="10dp"
         android:layout_marginBottom="10dp"
-        app:cardBackgroundColor="@android:color/white"
         app:cardCornerRadius="4dp"
         app:cardElevation="5dp"
         app:cardUseCompatPadding="true">
@@ -57,7 +55,6 @@
         android:id="@+id/recyclerView"
         tools:listitem="@layout/item_country_picker"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/colorBottomSheetListBackground" />
+        android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/lib/src/main/res/layout/bottom_sheet_country_picker.xml
+++ b/lib/src/main/res/layout/bottom_sheet_country_picker.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 
     <LinearLayout
@@ -54,6 +55,7 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
+        tools:listitem="@layout/item_country_picker"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/colorBottomSheetListBackground" />

--- a/lib/src/main/res/layout/item_country_picker.xml
+++ b/lib/src/main/res/layout/item_country_picker.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:paddingVertical="12dp"
     android:paddingHorizontal="18dp"
@@ -11,12 +12,14 @@
 
     <ImageView
         android:id="@+id/imageViewFlag"
+        tools:src="@drawable/country_flag_tr"
         android:layout_width="22dp"
         android:layout_height="22dp" />
 
     <TextView
         android:id="@+id/textViewName"
         android:layout_width="0dp"
+        tools:text="Turkey (Türkiye)"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:layout_marginStart="16dp"
@@ -32,6 +35,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="16sp"
+        tools:text="90"
         android:textColor="#838383" />
 
 </LinearLayout>

--- a/lib/src/main/res/layout/item_country_picker.xml
+++ b/lib/src/main/res/layout/item_country_picker.xml
@@ -7,16 +7,15 @@
     android:paddingVertical="12dp"
     android:paddingHorizontal="18dp"
     android:clickable="true"
-    android:focusable="true"
-    android:background="?android:attr/selectableItemBackground">
+    android:focusable="true">
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/imageViewFlag"
         tools:src="@drawable/country_flag_tr"
         android:layout_width="22dp"
         android:layout_height="22dp" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textViewName"
         android:layout_width="0dp"
         tools:text="Turkey (Türkiye)"
@@ -27,15 +26,13 @@
         android:singleLine="true"
         android:maxLines="1"
         android:ellipsize="end"
-        android:textSize="16sp"
-        android:textColor="#232425" />
+        android:textSize="16sp"/>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textViewCode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="16sp"
-        tools:text="90"
-        android:textColor="#838383" />
+        tools:text="90" />
 
 </LinearLayout>

--- a/lib/src/main/res/values/style.xml
+++ b/lib/src/main/res/values/style.xml
@@ -3,7 +3,6 @@
 
     <style name="ThemeOverlay.PhoneNumberKit.BottomSheetDialog" parent="@style/ThemeOverlay.MaterialComponents.BottomSheetDialog">
         <item name="bottomSheetStyle">@style/Widget.PhoneNumberKit.BottomSheet</item>
-        <item name="colorSurface">@color/colorBottomSheetBackground</item>
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowSoftInputMode">adjustResize</item>
     </style>


### PR DESCRIPTION
Support dark mode using material components library. It used theme colors. If the user uses a dark mode theme in the application, the library will support dark mode too.

Light theme:
<img src="https://user-images.githubusercontent.com/1575881/131249795-d5efaf65-0aa3-4142-91b9-6bda8105339b.png" width="240">

Dark theme:
<img src="https://user-images.githubusercontent.com/1575881/131249796-9e01349b-1126-4a05-a7a5-89c5e9f7c0aa.png" width="240">
