### PR TITLE
Fix: Add missing long phone number patterns for Austria (AT)

### DIFF
--- a/lib/src/main/java/me/ibrahimsn/lib/internal/model/State.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/internal/model/State.kt
@@ -10,5 +10,6 @@ sealed class State {
     data class Attached(
         val country: Country,
         val pattern: String,
+        val otherPatterns: List<String>,
     ) : State()
 }


### PR DESCRIPTION
- Implemented `findOtherPatterns` function to find others shorter or longer patterns.
- Addressed issue where text input validation for Austrian phone numbers failed for valid long numbers.

Fixes #14